### PR TITLE
Add default type for close icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.1] - 2019-05-14
 ### Changed
 - Add default `type` of `filled` on `IconClose` component.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add default `type` of `filled` on `IconClose` component.
 
 ## [0.10.0] - 2019-04-16
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-icons",
   "vendor": "vtex",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "title": "VTEX Store icons",
   "description": "All icons that store apps use.",
   "mustUpdateAt": "2020-01-30",

--- a/react/IconClose.tsx
+++ b/react/IconClose.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 import { getType } from './utils/helpers'
 
-const IconClose = ({ type, ...props }: EnhancedIconProps) => {
+const IconClose = ({ type = 'filled', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
   return <Icon id={`sti-close${typeModifier}`} {...props} />
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a default `type` for the `IconClose` component.

#### What problem is this solving?
If you use the component as `<IconClose />` nothing shows up in the svg and the id of the `use` element is `#sti-closeundefined`, so I think it should have at least a default value defined so other devs don't need to always define it.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
