### PR TITLE
Add interfaces for individual icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Interfaces for each individual icon component.
 
 ## [0.13.4] - 2019-10-28
 ### Chore

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ All Store icons components.
       - [Navigation](#navigation)
       - [Status Indicators](#status-indicators)
   - [Customize](#customize)
-    - [Overwriting the default IconPack](#overwriting-the-default-iconpack) 
+    - [Overwriting the default IconPack](#overwriting-the-default-iconpack)
     - [Nomenclature](#nomenclature)
       - [Icon Intention](#icon-intention)
   - [Troubleshooting](#troubleshooting)
@@ -55,6 +55,8 @@ First of all, add into the dependencies of your `manifest.json` and use it as an
 }
 ```
 
+There are two different ways to use the icons available here. If you're developing a store's theme, you should use the `icon` block, which behaves just like any other block and expects to receive the props exposed by its [API](#props). But if you're developing custom components and want to use icons defined here, just follow the instructions below.
+
 ### Dedicated Icon
 
 Import the desired icon and use it into your code, for example:
@@ -62,9 +64,7 @@ Import the desired icon and use it into your code, for example:
 ```js
 import { IconMenu } from 'vtex.store-icons'
 
-const YourComponent = props => (
-  <IconMenu />
-)
+const YourComponent = props => <IconMenu />
 ```
 
 You can see [here](#icon-list) a list of every available icon.
@@ -89,12 +89,13 @@ const YourComponent = props => <Icon id="hpa-cart" />
 
 Any icon can receive the following props:
 
-| Property | Description | Type | Default value |
-| --- | --- | --- | --- |
-| size | Desired size | `Number` | 16 | 
-| isActive | desc | `Boolean` | true |
-| activeClassName | The className it should have if active | `String` | 🚫 |
-| mutedClassName | The className it should have if not active | `String` | 🚫 |
+| Property        | Description                                | Type      | Default value |
+| --------------- | ------------------------------------------ | --------- | ------------- |
+| id              | The ID for the desired icon                | `String`  | ''            |
+| size            | Desired size                               | `Number`  | 16            |
+| isActive        | desc                                       | `Boolean` | true          |
+| activeClassName | The className it should have if active     | `String`  | 🚫            |
+| mutedClassName  | The className it should have if not active | `String`  | 🚫            |
 
 Obs: **...props**: It is important to notice that any other `<svg>` prop passed will work with an icon as well.
 
@@ -102,60 +103,61 @@ Obs: **...props**: It is important to notice that any other `<svg>` prop passed 
 
 Some components support modifiers. These are props that define the icon type, orientation, state or shape.
 
-| Modifier | Possible values |
-| --- | --- |
-| type | `filled` `line` `outline` |
-| orientation | `up` `down` `left` `right` |
-| state | `on` `off` |
-| shape | `square` `rounded` `circle` |
+| Modifier    | Possible values             |
+| ----------- | --------------------------- |
+| type        | `filled` `line` `outline`   |
+| orientation | `up` `down` `left` `right`  |
+| state       | `on` `off`                  |
+| shape       | `square` `rounded` `circle` |
 
 ### Icon List
 
 #### Brand
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
-| [IconSocial](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSocial.js) | `social` | 🚫 | 🚫 | 🚫 | square \| rounded \| circle |
+
+| Component                                                                                    | id       | Type | Orientation | State | Shape                       |
+| -------------------------------------------------------------------------------------------- | -------- | ---- | ----------- | ----- | --------------------------- |
+| [IconSocial](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSocial.js) | `social` | 🚫   | 🚫          | 🚫    | square \| rounded \| circle |
 
 #### High Priority Actions
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
-| [IconArrowBack](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconArrowBack.js) | `arrow-back` |  🚫 | 🚫 | 🚫 | 🚫 |
-| [IconAssistantSales](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconAssistantSales.js) |`assistant-sales` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconProfile](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconProfile.js) | `profile` | 🚫 | 🚫 |  🚫 | 🚫 |
-| [IconCart](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCart.js) | `cart` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconSearch](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSearch.js)  | `search` | 🚫  | 🚫 | 🚫 | 🚫 |
-| [IconDelete](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconDelete.js) | `delete` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconMenu](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconMenu.js) | `menu` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconLocationMarker](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconLocationMarker.js) | `location-marker` | 🚫  |  🚫 | 🚫 | 🚫 |
 
-#### Middle Priority Actions
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
-| [IconEyesight](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconEyesight.js) | `eyesight` | filled \| outline | 🚫 | on \| off | 🚫 |
-| [IconMinus](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconMinus.js) | `minus` | filled \| outline \| line | 🚫 | 🚫 brands
-| [IconPlus](https://github.com/vtex-apps/store-icons/blobrandseact/IconPlus.js) | `plus` | filled \| outline \| line | 🚫 | 🚫 | 🚫 |brands
-| [IconSingleItem](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSingleItem.js) | `single-item` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconList](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconList.js) | `list` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconGallery](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconGallery.js) | `gallery` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconRemove](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconRemove.js) | `remove` | 🚫 |     🚫 |  🚫 | 🚫 |
-| [IconSwap](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSwap.js) | `swap` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconHeart](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconHeart.js) | `heart` | 🚫 | 🚫 | 🚫 | 🚫 |
-| [IconGlobe](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconGlobe.js) | `globe` | 🚫 | 🚫 | 🚫 | 🚫 |
+| Component                                                                                                    | id                | Type | Orientation | State | Shape |
+| ------------------------------------------------------------------------------------------------------------ | ----------------- | ---- | ----------- | ----- | ----- |
+| [IconArrowBack](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconArrowBack.js)           | `arrow-back`      | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconAssistantSales](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconAssistantSales.js) | `assistant-sales` | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconProfile](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconProfile.js)               | `profile`         | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconCart](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCart.js)                     | `cart`            | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconSearch](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSearch.js)                 | `search`          | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconDelete](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconDelete.js)                 | `delete`          | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconMenu](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconMenu.js)                     | `menu`            | 🚫   | 🚫          | 🚫    | 🚫    |
+| [IconLocationMarker](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconLocationMarker.js) | `location-marker` | 🚫   | 🚫          | 🚫    | 🚫    |
 
-#### Informational
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
+#### Medium Priority Actions
+
+| Component                                                                                            | id            | Type                      | Orientation | State     | Shape |
+| ---------------------------------------------------------------------------------------------------- | ------------- | ------------------------- | ----------- | --------- | ----- |
+| [IconEyesight](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconEyesight.js)     | `eyesight`    | filled \| outline         | 🚫          | on \| off | 🚫    |
+| [IconMinus](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconMinus.js)           | `minus`       | filled \| outline \| line | 🚫          | 🚫 brands |
+| [IconPlus](https://github.com/vtex-apps/store-icons/blobrandseact/IconPlus.js)                       | `plus`        | filled \| outline \| line | 🚫          | 🚫        | 🚫    | brands |
+| [IconSingleItem](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSingleItem.js) | `single-item` | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconList](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconList.js)             | `list`        | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconGallery](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconGallery.js)       | `gallery`     | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconRemove](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconRemove.js)         | `remove`      | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconSwap](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconSwap.js)             | `swap`        | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconHeart](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconHeart.js)           | `heart`       | 🚫                        | 🚫          | 🚫        | 🚫    |
+| [IconGlobe](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconGlobe.js)           | `globe`       | 🚫                        | 🚫          | 🚫        | 🚫    |
 
 #### Navigation
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
-| [IconCaret](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCaret.js) | `caret` | 🚫 | up \| down \| left \| right | 🚫 | 🚫 | true \| false |
+
+| Component                                                                                  | id      | Type | Orientation                 | State | Shape |
+| ------------------------------------------------------------------------------------------ | ------- | ---- | --------------------------- | ----- | ----- |
+| [IconCaret](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCaret.js) | `caret` | 🚫   | up \| down \| left \| right | 🚫    | 🚫    | true \| false |
 
 #### Status Indicators
-| Component | id | Type | Orientation | State| Shape |
-| --- | --- | --- | --- | --- | --- |
-| [IconClose](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconClose.js) | `close` | filled \| outline | 🚫 | 🚫 | 🚫 |
-| [IconCheck](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCheck.js) | `check` | filled \| outline \| line | 🚫 | 🚫 | 🚫 |
+
+| Component                                                                                  | id      | Type                      | Orientation | State | Shape |
+| ------------------------------------------------------------------------------------------ | ------- | ------------------------- | ----------- | ----- | ----- |
+| [IconClose](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconClose.js) | `close` | filled \| outline         | 🚫          | 🚫    | 🚫    |
+| [IconCheck](https://github.com/vtex-apps/store-icons/blob/feature/docs/react/IconCheck.js) | `check` | filled \| outline \| line | 🚫          | 🚫    | 🚫    |
 
 ## Customize
 
@@ -175,24 +177,24 @@ As mentioned before, all icon IDs are stored at the [iconpack.svg](https://githu
 
 The naming convention is: [`intention`](#icon-intention)-[`id`](#icon-list)--[`?modifiers`](#enhanced-props)
 
-Where the `modifiers` follows the rule: 
+Where the `modifiers` follows the rule:
 `?type`--`?orientation`--`?state`--`?shape`
 
 **🤓 ? stands for optional inputs**
 
 #### Icon Intention
+
 `bnd` **Brand** - Display logos, brands or advertisements.
 
 `hpa` **High priority actions** - Actions that are important to the global context.
 
 `mpa` **Mild priority actions** - Actions that are important only to the current component context.
 
-`inf` **Informational** - Represents information display or actions that, when triggered, reveal further details about the current context. 
+`inf` **Informational** - Represents information display or actions that, when triggered, reveal further details about the current context.
 
 `nav` **Navigation** - Actions that triggers navigation.
 
 `sti` **Status indicators** - Indicates the current item/component semantic status.
-
 
 ## Troubleshooting
 
@@ -200,7 +202,7 @@ You can check if others are passing through similar issues [here](https://github
 
 ## Contributing
 
-Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project. 
+Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project.
 
 ## Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ First of all, add into the dependencies of your `manifest.json` and use it as an
 }
 ```
 
-There are two different ways to use the icons available here. If you're developing a store's theme, you should use the `icon` block, which behaves just like any other block and expects to receive the props exposed by its [API](#props). But if you're developing custom components and want to use icons defined here, just follow the instructions below.
+There are two different ways to use the icons available here. If you're developing a store's theme, you should use the `icon` block for the icon you want to render, which behaves just like any other block and expects to receive the props exposed by its [API](#props). But if you're developing custom components and want to use icons defined here, just follow the instructions below.
 
 ### Dedicated Icon
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
   "builders": {
     "react": "3.x",
     "styles": "1.x",
+    "store": "0.x",
     "docs": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/react/Icon.tsx
+++ b/react/Icon.tsx
@@ -1,4 +1,3 @@
-
 import Icon from './components/Icon'
 
 export default Icon

--- a/react/utils/helpers.ts
+++ b/react/utils/helpers.ts
@@ -1,12 +1,12 @@
-import { find, propEq, contains } from 'ramda'
-import { ORIENTATIONS, STATES, TYPES, SHAPES } from './enhancements'
+import { contains, find, propEq } from 'ramda'
+import { ORIENTATIONS, SHAPES, STATES, TYPES } from './enhancements'
 
 /**
  * Get the modifer from any collection matching the rule collection{id, modifier}
  * @param {*} id
  * @param {*} collection
  */
-export const getModifier = (collection: Array<Enhancement>, id?: string) => {
+export const getModifier = (collection: Enhancement[], id?: string) => {
   const foundItem = find(propEq('id', id), collection)
   return !!foundItem ? foundItem.modifier : id
 }
@@ -16,7 +16,7 @@ export const getModifier = (collection: Array<Enhancement>, id?: string) => {
  * @param {*} tokens
  * @param {*} collection
  */
-export const getSubset = (tokens: string, collection: Array<Enhancement>) => {
+export const getSubset = (tokens: string, collection: Enhancement[]) => {
   const ids = tokens.split(',').join('')
   return collection.filter((item: any) => contains(item.id, ids))
 }
@@ -28,7 +28,7 @@ export const getSubset = (tokens: string, collection: Array<Enhancement>) => {
  * @param supported all supported enhancement list
  */
 export const getEnhancement = (
-  enhancementList: Array<Enhancement>,
+  enhancementList: Enhancement[],
   enhancement?: string,
   supported?: string
 ) => {
@@ -85,7 +85,7 @@ export const getShape = (
 
   const wrapperProps = [
     { className: `${modifiers} flex` },
-    { style: { padding: padding, backgroundColor: background } },
+    { style: { padding, backgroundColor: background } },
   ]
 
   return { wrapperProps, reducedIconSize }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,0 +1,5 @@
+{
+  "icon": {
+    "component": "Icon"
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,86 @@
 {
   "icon": {
     "component": "Icon"
+  },
+  "icon-arrow-back": {
+    "component": "IconArrowBack"
+  },
+  "icon-assistant-sales": {
+    "component": "IconAssistantSales"
+  },
+  "icon-caret": {
+    "component": "IconCaret"
+  },
+  "icon-cart": {
+    "component": "IconCart"
+  },
+  "icon-check": {
+    "component": "IconCheck"
+  },
+  "icon-close": {
+    "component": "IconClose"
+  },
+  "icon-delete": {
+    "component": "IconDelete"
+  },
+  "icon-equals": {
+    "component": "IconEquals"
+  },
+  "icon-eye-sight": {
+    "component": "IconEyeSight"
+  },
+  "icon-filter": {
+    "component": "IconFilter"
+  },
+  "icon-globe": {
+    "component": "IconGlobe"
+  },
+  "icon-grid": {
+    "component": "IconGrid"
+  },
+  "icon-heart": {
+    "component": "IconHeart"
+  },
+  "icon-home": {
+    "component": "IconHome"
+  },
+  "icon-inline-grid": {
+    "component": "IconInlineGrid"
+  },
+  "icon-location-input": {
+    "component": "IconLocationInput"
+  },
+  "icon-location-marker": {
+    "component": "IconLocationMarker"
+  },
+  "icon-menu": {
+    "component": "IconMenu"
+  },
+  "icon-minus": {
+    "component": "IconMinus"
+  },
+  "icon-plus": {
+    "component": "IconPlus"
+  },
+  "icon-profile": {
+    "component": "IconProfile"
+  },
+  "icon-remove": {
+    "component": "IconRemove"
+  },
+  "icon-search": {
+    "component": "IconSearch"
+  },
+  "icon-single-grid": {
+    "component": "IconSingleGrid"
+  },
+  "icon-social": {
+    "component": "IconSocial"
+  },
+  "icon-star": {
+    "component": "IconStar"
+  },
+  "icon-swap": {
+    "component": "IconSwap"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable users to configure each icon individually using then as blocks passed to other blocks.

#### What problem is this solving?

We would have to expose a new prop, or even multiple different props in every component that uses `store-icons` to enable our users to customize prop values passed to each icon.

Now, we don't need to extend the APIs in any component, but just make them use `<ExtensionPoint />`s.

#### How should this be manually tested?

[Workspace](https://storeicons--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
