### PR TITLE
feature/custom-fill-color

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@ Any icon can receive the following props:
 | Property        | Description                                | Type      | Default value |
 | --------------- | ------------------------------------------ | --------- | ------------- |
 | id              | The ID for the desired icon                | `String`  | ''            |
+| fill            | The desired icon color                     | `String`  | 'none'        |
 | size            | Desired size                               | `Number`  | 16            |
 | isActive        | desc                                       | `Boolean` | true          |
 | activeClassName | The className it should have if active     | `String`  | 🚫            |

--- a/react/__tests__/Icon.test.tsx
+++ b/react/__tests__/Icon.test.tsx
@@ -8,4 +8,8 @@ describe('Icon', () => {
     const component = render(<Icon id="tst-snapshot" size={20} />).asFragment()
     expect(component).toMatchSnapshot()
   })
+  it('should match snapshot', () => {
+    const component = render(<Icon id="tst-snapshot" size={30} fill="pink" />).asFragment()
+    expect(component).toMatchSnapshot()
+  })
 })

--- a/react/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/react/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -17,3 +17,22 @@ exports[`Icon should match snapshot 1`] = `
   </svg>
 </DocumentFragment>
 `;
+
+exports[`Icon should match snapshot 2`] = `
+<DocumentFragment>
+  <svg
+    fill="pink"
+    height="30"
+    viewBox="0 0 16 16"
+    width="30"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+  >
+    <use
+      href="#tst-snapshot"
+      xlink:href="#tst-snapshot"
+    />
+  </svg>
+</DocumentFragment>
+`;
+

--- a/react/components/Icon.tsx
+++ b/react/components/Icon.tsx
@@ -8,13 +8,14 @@ import './icon.global.css'
 const Icon = ({
   id,
   isActive,
+  fill,
   size,
   viewBox,
   activeClassName,
   mutedClassName,
 }: IconProps) => (
   <Svg
-    fill="none"
+    fill={fill || 'none'}
     width={size}
     height={size}
     viewBox={viewBox}

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.store-icons",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "React components that encapsules store icons",
   "scripts": {
     "pretest": "yarn",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,6 +1,7 @@
 interface IconProps {
   readonly id: string
   readonly isActive?: boolean
+  readonly fill?: string
   readonly size?: number
   readonly viewBox?: string
   readonly activeClassName?: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible to define SVG fill color on React, instead of using CSS to accomplish that. Other attributes like `viewBox` and `width` are open to customization. There is no apparent reason to keep `fill` edition blocked.

#### What problem is this solving?

SVG files that rely on the fill attribute (instead of `line`) are rendered, but "look" transparent due to the `fill="none"` attribute. This feature applies any `fill` value received from `<Icon/>` component on the SVG. If it got no value, it keeps the "none" to prevent any unexpected behaviour.

#### How should this be manually tested?

There's a new test to validate it, using `yarn test`.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
