### PR TITLE
Add CSS handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CSS handles to all icons.
 
 ## [0.15.0] - 2019-12-27
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,10 @@
+📢 Use this project, [contribute](https://github.com/vtex-apps/store-icons) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+
 # Store Icons
 
 [![Build Status](https://travis-ci.org/vtex-apps/store-icons.svg?branch=master)](https://travis-ci.org/vtex-apps/store-icons)
 
-## Description
-
 All Store icons components.
-
-**Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
-
-## Release schedule
-
-| Release |       Status        | Initial Release | Maintenance LTS Start | End-of-life | Store Compatibility |
-| :-----: | :-----------------: | :-------------: | :-------------------: | :---------: | :-----------------: |
-|  [0.x]  | **Current Release** |   2019-01-30    |      -----------      | ----------  |         2.x         |
 
 ## Table of Contents
 
@@ -197,14 +189,36 @@ Where the `modifiers` follows the rule:
 
 `sti` **Status indicators** - Indicates the current item/component semantic status.
 
-## Troubleshooting
+## CSS Customization
 
-You can check if others are passing through similar issues [here](https://github.com/vtex-apps/store-icons/issues). Also feel free to [open issues](https://github.com/vtex-apps/store-icons/issues/new) or contribute with pull requests.
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-## Contributing
-
-Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project.
-
-## Tests
-
-To execute our tests go to `react/` folder and run `yarn test`
+| CSS Handles          |
+| -------------------- |
+| 'arrowBackIcon'      |
+| 'assistantSalesIcon' |
+| 'caretIcon'          |
+| 'cartIcon'           |
+| 'checkIcon'          |
+| 'closeIcon'          |
+| 'deleteIcon'         |
+| 'equalsIcon'         |
+| 'eyeSightIcon'       |
+| 'filterIcon'         |
+| 'globeIcon'          |
+| 'gridIcon'           |
+| 'heartIcon'          |
+| 'homeIcon'           |
+| 'inlineGridIcon'     |
+| 'locationInputIcon'  |
+| 'locationMarkerIcon' |
+| 'menuIcon'           |
+| 'minusIcon'          |
+| 'plusIcon'           |
+| 'profileIcon'        |
+| 'removeIcon'         |
+| 'searchIcon'         |
+| 'singleGridIcon'     |
+| 'socialIcon'         |
+| 'starIcon'           |
+| 'swapIcon'           |

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,9 @@
     "prereleasy": "yarn && node docs/script/scrap-svg.js",
     "postreleasy": "vtex publish --verbose"
   },
+  "dependencies": {
+    "vtex.css-handles": "0.x"
+  },
   "builders": {
     "react": "3.x",
     "styles": "1.x",

--- a/react/IconArrowBack.tsx
+++ b/react/IconArrowBack.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconArrowBack = (props: IconProps) => {
-  return <Icon id="hpa-arrow-back" {...props} />
+  return <Icon id="hpa-arrow-back" handle="arrowBackIcon" {...props} />
 }
 
 export default IconArrowBack

--- a/react/IconAssistantSales.tsx
+++ b/react/IconAssistantSales.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconAssistantSales = (props: IconProps) => {
-  return <Icon id="hpa-telemarketing" {...props} />
+  return <Icon id="hpa-telemarketing" handle="assistantSalesIcon" {...props} />
 }
 
 export default IconAssistantSales

--- a/react/IconCaret.tsx
+++ b/react/IconCaret.tsx
@@ -7,9 +7,9 @@ const IconCaret = ({ orientation, thin = false, ...props }: CaretProps) => {
   const orientationModifier = getOrientation(orientation)
   const id: string = classnames({
     [`nav-thin-caret${orientationModifier}`]: thin,
-    [`nav-caret${orientationModifier}`]: !thin
+    [`nav-caret${orientationModifier}`]: !thin,
   })
-  return <Icon id={id} {...props} />
+  return <Icon id={id} handle="caretIcon" {...props} />
 }
 
 export default IconCaret

--- a/react/IconCart.tsx
+++ b/react/IconCart.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconCart = (props: IconProps) => {
-  return <Icon id="hpa-cart" {...props} />
+  return <Icon id="hpa-cart" handle="cartIcon" {...props} />
 }
 
 export default IconCart

--- a/react/IconCheck.tsx
+++ b/react/IconCheck.tsx
@@ -5,9 +5,7 @@ import Icon from './components/Icon'
 
 const IconCheck = ({ type, ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
-  return <Icon id={`sti-check${typeModifier}`} {...props} />
+  return <Icon handle="checkIcon" id={`sti-check${typeModifier}`} {...props} />
 }
-
-
 
 export default IconCheck

--- a/react/IconClose.tsx
+++ b/react/IconClose.tsx
@@ -5,7 +5,7 @@ import { getType } from './utils/helpers'
 
 const IconClose = ({ type = 'filled', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
-  return <Icon id={`sti-close${typeModifier}`} {...props} />
+  return <Icon handle="closeIcon" id={`sti-close${typeModifier}`} {...props} />
 }
 
 export default IconClose

--- a/react/IconDelete.tsx
+++ b/react/IconDelete.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconDelete = (props: IconProps) => {
-  return <Icon id="hpa-delete" {...props} />
+  return <Icon id="hpa-delete" handle="deleteIcon" {...props} />
 }
 
 export default IconDelete

--- a/react/IconEquals.tsx
+++ b/react/IconEquals.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconEquals = (props: IconProps) => {
-  return <Icon id="sti-equals" {...props} />
+  return <Icon id="sti-equals" handle="equalsIcon" {...props} />
 }
 
 export default IconEquals

--- a/react/IconEyeSight.tsx
+++ b/react/IconEyeSight.tsx
@@ -6,7 +6,13 @@ import { getType, getState } from './utils/helpers'
 const IconEyeSight = ({ type, state, ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type, 'filled, outline')
   const stateModifier = getState(state)
-  return <Icon id={`mpa-eyesight${typeModifier}${stateModifier}`} {...props} />
+  return (
+    <Icon
+      id={`mpa-eyesight${typeModifier}${stateModifier}`}
+      handle="eyeSightIcon"
+      {...props}
+    />
+  )
 }
 
 export default IconEyeSight

--- a/react/IconFilter.tsx
+++ b/react/IconFilter.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconFilter = (props: IconProps) => {
-  return <Icon id="mpa-filter-settings" {...props} />
+  return <Icon id="mpa-filter-settings" handle="filterIcon" {...props} />
 }
 
 export default IconFilter

--- a/react/IconGlobe.tsx
+++ b/react/IconGlobe.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGlobe = (props: IconProps) => {
-  return <Icon id="mpa-globe" {...props} />
+  return <Icon id="mpa-globe" handle="globeIcon" {...props} />
 }
 
 export default IconGlobe

--- a/react/IconGrid.tsx
+++ b/react/IconGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGrid = (props: IconProps) => {
-  return <Icon id="mpa-gallery" {...props} />
+  return <Icon id="mpa-gallery" handle="gridIcon" {...props} />
 }
 
 export default IconGrid

--- a/react/IconHeart.tsx
+++ b/react/IconHeart.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHeart = (props: IconProps) => {
-  return <Icon id="mpa-heart" {...props} />
+  return <Icon id="mpa-heart" handle="heartIcon" {...props} />
 }
 
 export default IconHeart

--- a/react/IconHome.tsx
+++ b/react/IconHome.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHome = (props: IconProps) => {
-  return <Icon id="nav-home" {...props} />
+  return <Icon id="nav-home" handle="homeIcon" {...props} />
 }
 
 export default IconHome

--- a/react/IconInlineGrid.tsx
+++ b/react/IconInlineGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconInlineGrid = (props: IconProps) => {
-  return <Icon id="mpa-list-items" {...props} />
+  return <Icon id="mpa-list-items" handle="inlineGridIcon" {...props} />
 }
 
 export default IconInlineGrid

--- a/react/IconLocationInput.tsx
+++ b/react/IconLocationInput.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
- import Icon from './components/Icon'
+import Icon from './components/Icon'
 
- const IconLocationInput = (props: IconProps) => {
-  return <Icon id="mpa-location-input" {...props} />
+const IconLocationInput = (props: IconProps) => {
+  return <Icon id="mpa-location-input" handle="locationInputIcon" {...props} />
 }
 
- export default IconLocationInput
+export default IconLocationInput

--- a/react/IconLocationMarker.tsx
+++ b/react/IconLocationMarker.tsx
@@ -3,7 +3,9 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconLocationMarker = (props: IconProps) => {
-  return <Icon id="hpa-location-marker" {...props} />
+  return (
+    <Icon id="hpa-location-marker" handle="locationMarkerIcon" {...props} />
+  )
 }
 
 export default IconLocationMarker

--- a/react/IconMenu.tsx
+++ b/react/IconMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMenu = (props: IconProps) => {
-  return <Icon id="hpa-hamburguer-menu" {...props} />
+  return <Icon id="hpa-hamburguer-menu" handle="menuIcon" {...props} />
 }
 
 export default IconMenu

--- a/react/IconMinus.tsx
+++ b/react/IconMinus.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMinus = (props: IconProps) => {
-  return <Icon id="nav-minus" {...props} />
+  return <Icon id="nav-minus" handle="minusIcon" {...props} />
 }
 
 export default IconMinus

--- a/react/IconPlus.tsx
+++ b/react/IconPlus.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPlus = (props: IconProps) => {
-  return <Icon id="nav-plus" {...props} />
+  return <Icon id="nav-plus" handle="plusIcon" {...props} />
 }
 
 export default IconPlus

--- a/react/IconProfile.tsx
+++ b/react/IconProfile.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconProfile = (props: IconProps) => {
-  return <Icon id="hpa-profile" {...props} />
+  return <Icon id="hpa-profile" handle="profileIcon" {...props} />
 }
 
 export default IconProfile

--- a/react/IconRemove.tsx
+++ b/react/IconRemove.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconRemove = (props: IconProps) => {
-  return <Icon id="mpa-remove" {...props} />
+  return <Icon id="mpa-remove" handle="removeIcon" {...props} />
 }
 
 export default IconRemove

--- a/react/IconSearch.tsx
+++ b/react/IconSearch.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSearch = (props: IconProps) => {
-  return <Icon id="hpa-search" {...props} />
+  return <Icon id="hpa-search" handle="searchIcon" {...props} />
 }
 
 export default IconSearch

--- a/react/IconSingleGrid.tsx
+++ b/react/IconSingleGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSingleGrid = (props: IconProps) => {
-  return <Icon id="mpa-single-item" {...props} />
+  return <Icon id="mpa-single-item" handle="singleGridIcon" {...props} />
 }
 
 export default IconSingleGrid

--- a/react/IconSocial.tsx
+++ b/react/IconSocial.tsx
@@ -13,7 +13,12 @@ const IconSocial = ({ network, size, background, shape, ...props }: Props) => {
 
   return (
     <span {...wrapperProps}>
-      <Icon id={`bnd-${network}`} size={reducedIconSize} {...props} />
+      <Icon
+        id={`bnd-${network}`}
+        handle="socialIcon"
+        size={reducedIconSize}
+        {...props}
+      />
     </span>
   )
 }

--- a/react/IconStar.tsx
+++ b/react/IconStar.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconStar = (props: IconProps) => {
-  return <Icon id="inf-star" {...props} />
+  return <Icon id="inf-star" handle="starIcon" {...props} />
 }
 
 export default IconStar

--- a/react/IconSwap.tsx
+++ b/react/IconSwap.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSwap = (props: IconProps) => {
-  return <Icon id="mpa-swap" {...props} />
+  return <Icon id="mpa-swap" handle="swapIcon" {...props} />
 }
 
 export default IconSwap

--- a/react/__mocks__/vtex.css-handles.ts
+++ b/react/__mocks__/vtex.css-handles.ts
@@ -1,0 +1,3 @@
+export function useCssHandles() {
+  return { handle: 'handle' }
+}

--- a/react/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/react/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Icon should match snapshot 1`] = `
 <DocumentFragment>
   <svg
+    class=" "
     fill="none"
     height="20"
     viewBox="0 0 16 16"

--- a/react/components/Icon.tsx
+++ b/react/components/Icon.tsx
@@ -1,28 +1,66 @@
 import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
 
 import Use from './Use'
 import Svg from './Svg'
 
 import './icon.global.css'
 
+const CSS_HANDLES = [
+  'arrowBackIcon',
+  'assistantSalesIcon',
+  'caretIcon',
+  'cartIcon',
+  'checkIcon',
+  'closeIcon',
+  'deleteIcon',
+  'equalsIcon',
+  'eyeSightIcon',
+  'filterIcon',
+  'globeIcon',
+  'gridIcon',
+  'heartIcon',
+  'homeIcon',
+  'inlineGridIcon',
+  'locationInputIcon',
+  'locationMarkerIcon',
+  'menuIcon',
+  'minusIcon',
+  'plusIcon',
+  'profileIcon',
+  'removeIcon',
+  'searchIcon',
+  'singleGridIcon',
+  'socialIcon',
+  'starIcon',
+  'swapIcon',
+] as const
+
 const Icon = ({
   id,
+  handle,
   isActive,
   size,
   viewBox,
   activeClassName,
   mutedClassName,
-}: IconProps) => (
-  <Svg
-    fill="none"
-    width={size}
-    height={size}
-    viewBox={viewBox}
-    className={isActive ? activeClassName : mutedClassName}
-  >
-    <Use id={id} />
-  </Svg>
-)
+}: IconProps) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return (
+    <Svg
+      fill="none"
+      width={size}
+      height={size}
+      viewBox={viewBox}
+      className={`${isActive ? activeClassName : mutedClassName} ${
+        handles[handle]
+      }`}
+    >
+      <Use id={id} />
+    </Svg>
+  )
+}
 
 Icon.defaultProps = {
   isActive: true,

--- a/react/components/Icon.tsx
+++ b/react/components/Icon.tsx
@@ -53,9 +53,9 @@ const Icon = ({
       width={size}
       height={size}
       viewBox={viewBox}
-      className={`${isActive ? activeClassName : mutedClassName} ${
-        handles[handle]
-      }`}
+      className={`${
+        isActive ? activeClassName || '' : mutedClassName || ''
+      } ${handles[handle] || ''}`}
     >
       <Use id={id} />
     </Svg>

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,5 +1,6 @@
 interface IconProps {
   readonly id: string
+  readonly handle: string
   readonly isActive?: boolean
   readonly size?: number
   readonly viewBox?: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add CSS handles to all icons.

#### What problem is this solving?

The `<svg>`s rendered for each icon did not have CSS handles, that way they could not be fully customized by users.

#### How should this be manually tested?

https://handleonstoreicons--storecomponents.myvtex.com

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
