### PR TITLE
Default class

### DIFF
--- a/react/IconArrowBack.tsx
+++ b/react/IconArrowBack.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconArrowBack = (props: IconProps) => {
-  return <Icon id="hpa-arrow-back" handle="arrowBackIcon" {...props} />
+  return <Icon {...props} id="hpa-arrow-back" handle="arrowBackIcon"   />
 }
 
 export default IconArrowBack

--- a/react/IconAssistantSales.tsx
+++ b/react/IconAssistantSales.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconAssistantSales = (props: IconProps) => {
-  return <Icon id="hpa-telemarketing" handle="assistantSalesIcon" {...props} />
+  return <Icon {...props} id="hpa-telemarketing" handle="assistantSalesIcon"   />
 }
 
 export default IconAssistantSales

--- a/react/IconBookmark.tsx
+++ b/react/IconBookmark.tsx
@@ -5,7 +5,7 @@ import { getType } from './utils/helpers'
 
 const IconBoomark = ({ type = 'outline', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type, 'filled, outline')
-  return <Icon id={`mpa-bookmark${typeModifier}`} {...props} />
+  return <Icon {...props} id={`mpa-bookmark${typeModifier}`}   />
 }
 
 export default IconBoomark

--- a/react/IconCaret.tsx
+++ b/react/IconCaret.tsx
@@ -9,7 +9,7 @@ const IconCaret = ({ orientation, thin = false, ...props }: CaretProps) => {
     [`nav-thin-caret${orientationModifier}`]: thin,
     [`nav-caret${orientationModifier}`]: !thin,
   })
-  return <Icon id={id} handle="caretIcon" {...props} />
+  return <Icon {...props} id={id} handle="caretIcon"   />
 }
 
 export default IconCaret

--- a/react/IconCart.tsx
+++ b/react/IconCart.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconCart = (props: IconProps) => {
-  return <Icon id="hpa-cart" handle="cartIcon" {...props} />
+  return <Icon {...props} id="hpa-cart" handle="cartIcon"   />
 }
 
 export default IconCart

--- a/react/IconCheck.tsx
+++ b/react/IconCheck.tsx
@@ -5,7 +5,7 @@ import Icon from './components/Icon'
 
 const IconCheck = ({ type, ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
-  return <Icon handle="checkIcon" id={`sti-check${typeModifier}`} {...props} />
+  return <Icon {...props}handle="checkIcon" id={`sti-check${typeModifier}`}   />
 }
 
 export default IconCheck

--- a/react/IconClose.tsx
+++ b/react/IconClose.tsx
@@ -5,7 +5,7 @@ import { getType } from './utils/helpers'
 
 const IconClose = ({ type = 'filled', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
-  return <Icon handle="closeIcon" id={`sti-close${typeModifier}`} {...props} />
+  return <Icon {...props} handle="closeIcon" id={`sti-close${typeModifier}`}   />
 }
 
 export default IconClose

--- a/react/IconDelete.tsx
+++ b/react/IconDelete.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconDelete = (props: IconProps) => {
-  return <Icon id="hpa-delete" handle="deleteIcon" {...props} />
+  return <Icon {...props}id="hpa-delete" handle="deleteIcon"   />
 }
 
 export default IconDelete

--- a/react/IconEquals.tsx
+++ b/react/IconEquals.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconEquals = (props: IconProps) => {
-  return <Icon id="sti-equals" handle="equalsIcon" {...props} />
+  return <Icon {...props} id="sti-equals" handle="equalsIcon"   />
 }
 
 export default IconEquals

--- a/react/IconExpand.tsx
+++ b/react/IconExpand.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconExpand = (props: IconProps) => {
-  return <Icon id="mpa-expand" handle="expandIcon" {...props} />
+  return <Icon {...props} id="mpa-expand" handle="expandIcon"   />
 }
 
 export default IconExpand

--- a/react/IconEyeSight.tsx
+++ b/react/IconEyeSight.tsx
@@ -8,9 +8,10 @@ const IconEyeSight = ({ type, state, ...props }: EnhancedIconProps) => {
   const stateModifier = getState(state)
   return (
     <Icon
+      {...props}
       id={`mpa-eyesight${typeModifier}${stateModifier}`}
       handle="eyeSightIcon"
-      {...props}
+       
     />
   )
 }

--- a/react/IconFilter.tsx
+++ b/react/IconFilter.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconFilter = (props: IconProps) => {
-  return <Icon id="mpa-filter-settings" handle="filterIcon" {...props} />
+  return <Icon {...props} id="mpa-filter-settings" handle="filterIcon"   />
 }
 
 export default IconFilter

--- a/react/IconGlobe.tsx
+++ b/react/IconGlobe.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGlobe = (props: IconProps) => {
-  return <Icon id="mpa-globe" handle="globeIcon" {...props} />
+  return <Icon {...props} id="mpa-globe" handle="globeIcon"   />
 }
 
 export default IconGlobe

--- a/react/IconGrid.tsx
+++ b/react/IconGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGrid = (props: IconProps) => {
-  return <Icon id="mpa-gallery" handle="gridIcon" {...props} />
+  return <Icon {...props} id="mpa-gallery" handle="gridIcon"   />
 }
 
 export default IconGrid

--- a/react/IconHeart.tsx
+++ b/react/IconHeart.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHeart = (props: IconProps) => {
-  return <Icon id="mpa-heart" handle="heartIcon" {...props} />
+  return <Icon {...props} id="mpa-heart" handle="heartIcon"   />
 }
 
 export default IconHeart

--- a/react/IconHome.tsx
+++ b/react/IconHome.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHome = (props: IconProps) => {
-  return <Icon id="nav-home" handle="homeIcon" {...props} />
+  return <Icon {...props} id="nav-home" handle="homeIcon"   />
 }
 
 export default IconHome

--- a/react/IconInlineGrid.tsx
+++ b/react/IconInlineGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconInlineGrid = (props: IconProps) => {
-  return <Icon id="mpa-list-items" handle="inlineGridIcon" {...props} />
+  return <Icon {...props} id="mpa-list-items" handle="inlineGridIcon"   />
 }
 
 export default IconInlineGrid

--- a/react/IconLocationInput.tsx
+++ b/react/IconLocationInput.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconLocationInput = (props: IconProps) => {
-  return <Icon id="mpa-location-input" handle="locationInputIcon" {...props} />
+  return <Icon {...props} id="mpa-location-input" handle="locationInputIcon"   />
 }
 
 export default IconLocationInput

--- a/react/IconLocationMarker.tsx
+++ b/react/IconLocationMarker.tsx
@@ -4,7 +4,7 @@ import Icon from './components/Icon'
 
 const IconLocationMarker = (props: IconProps) => {
   return (
-    <Icon id="hpa-location-marker" handle="locationMarkerIcon" {...props} />
+    <Icon {...props} id="hpa-location-marker" handle="locationMarkerIcon"   />
   )
 }
 

--- a/react/IconMenu.tsx
+++ b/react/IconMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMenu = (props: IconProps) => {
-  return <Icon id="hpa-hamburguer-menu" handle="menuIcon" {...props} />
+  return <Icon {...props} id="hpa-hamburguer-menu" handle="menuIcon"   />
 }
 
 export default IconMenu

--- a/react/IconMinus.tsx
+++ b/react/IconMinus.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMinus = (props: IconProps) => {
-  return <Icon id="nav-minus" handle="minusIcon" {...props} />
+  return <Icon {...props} id="nav-minus" handle="minusIcon"   />
 }
 
 export default IconMinus

--- a/react/IconPause.tsx
+++ b/react/IconPause.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPause = (props: IconProps) => {
-  return <Icon id="mpa-pause" handle="pauseIcon" {...props} />
+  return <Icon {...props} id="mpa-pause" handle="pauseIcon"   />
 }
 
 export default IconPause

--- a/react/IconPlay.tsx
+++ b/react/IconPlay.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPlay = (props: IconProps) => {
-  return <Icon id="mpa-play" handle="playIcon" {...props} />
+  return <Icon {...props}   id="mpa-play" handle="playIcon" />
 }
 
 export default IconPlay

--- a/react/IconPlus.tsx
+++ b/react/IconPlus.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPlus = (props: IconProps) => {
-  return <Icon id="nav-plus" handle="plusIcon" {...props} />
+  return <Icon  {...props}  id="nav-plus" handle="plusIcon" />
 }
 
 export default IconPlus

--- a/react/IconProfile.tsx
+++ b/react/IconProfile.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconProfile = (props: IconProps) => {
-  return <Icon id="hpa-profile" handle="profileIcon" {...props} />
+  return <Icon  {...props}  id="hpa-profile" handle="profileIcon"/>
 }
 
 export default IconProfile

--- a/react/IconRemove.tsx
+++ b/react/IconRemove.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconRemove = (props: IconProps) => {
-  return <Icon id="mpa-remove" handle="removeIcon" {...props} />
+  return <Icon  {...props}  id="mpa-remove" handle="removeIcon" />
 }
 
 export default IconRemove

--- a/react/IconSearch.tsx
+++ b/react/IconSearch.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSearch = (props: IconProps) => {
-  return <Icon {...props}   id="hpa-search" handle="searchIcon" />
+  return <Icon {...props} id="hpa-search" handle="searchIcon" />
 }
 
 export default IconSearch

--- a/react/IconSearch.tsx
+++ b/react/IconSearch.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSearch = (props: IconProps) => {
-  return <Icon id="hpa-search" handle="searchIcon" {...props} />
+  return <Icon {...props}   id="hpa-search" handle="searchIcon" />
 }
 
 export default IconSearch

--- a/react/IconSingleGrid.tsx
+++ b/react/IconSingleGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSingleGrid = (props: IconProps) => {
-  return <Icon id="mpa-single-item" handle="singleGridIcon" {...props} />
+  return <Icon  {...props}  id="mpa-single-item" handle="singleGridIcon"/>
 }
 
 export default IconSingleGrid

--- a/react/IconSocial.tsx
+++ b/react/IconSocial.tsx
@@ -14,10 +14,10 @@ const IconSocial = ({ network, size, background, shape, ...props }: Props) => {
   return (
     <span {...wrapperProps}>
       <Icon
+        {...props}
         id={`bnd-${network}`}
         handle="socialIcon"
         size={reducedIconSize}
-        {...props}
       />
     </span>
   )

--- a/react/IconStar.tsx
+++ b/react/IconStar.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconStar = (props: IconProps) => {
-  return <Icon id="inf-star" handle="starIcon" {...props} />
+  return <Icon  {...props}  id="inf-star" handle="starIcon"/>
 }
 
 export default IconStar

--- a/react/IconSwap.tsx
+++ b/react/IconSwap.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSwap = (props: IconProps) => {
-  return <Icon id="mpa-swap" handle="swapIcon" {...props} />
+  return <Icon  {...props}  id="mpa-swap" handle="swapIcon" />
 }
 
 export default IconSwap

--- a/react/IconVolumeOff.tsx
+++ b/react/IconVolumeOff.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconVolumeOff = (props: IconProps) => {
-  return <Icon id="sti-volume-off" handle="volumeOffIcon" {...props} />
+  return <Icon {...props}   id="sti-volume-off" handle="volumeOffIcon"/>
 }
 
 export default IconVolumeOff

--- a/react/IconVolumeOn.tsx
+++ b/react/IconVolumeOn.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconVolumeOn = (props: IconProps) => {
-  return <Icon id="sti-volume-on" handle="volumeOnIcon" {...props} />
+  return <Icon {...props}   id="sti-volume-on" handle="volumeOnIcon"  />
 }
 
 export default IconVolumeOn

--- a/react/components/Icon.tsx
+++ b/react/components/Icon.tsx
@@ -58,7 +58,7 @@ const Icon = ({
       height={size}
       viewBox={viewBox}
       className={`${isActive ? activeClassName || '' : mutedClassName || ''} ${
-        handles[handle] || handles['icon'] `${handles['icon']}--${id}`
+        handles[handle] || handles['icon']
       }`}
     >
       <Use id={id} />

--- a/react/components/Icon.tsx
+++ b/react/components/Icon.tsx
@@ -37,6 +37,7 @@ const CSS_HANDLES = [
   'pauseIcon',
   'volumeOnIcon',
   'volumeOffIcon',
+  'icon'
 ] as const
 
 const Icon = ({
@@ -57,7 +58,7 @@ const Icon = ({
       height={size}
       viewBox={viewBox}
       className={`${isActive ? activeClassName || '' : mutedClassName || ''} ${
-        handles[handle] || ''
+        handles[handle] || handles['icon'] `${handles['icon']}--${id}`
       }`}
     >
       <Use id={id} />

--- a/react/package.json
+++ b/react/package.json
@@ -30,7 +30,7 @@
     "tslint": "^5.11.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "resolutions": {
     "babel-core": "^7.0.0-bridge.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4919,10 +4919,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What problem is this solving?

This PR add deafult class to custom icons, that prevent the use of another blocks to give a class to colorize or other css customizations. 

#### How to test it?

Just add a custom icon in your theme.

[Workspace](${handles['icon']}--${id})

#### Screenshots or example usage:

before
![image](https://user-images.githubusercontent.com/48053804/137961785-cd181dfb-dda9-4e3a-91ca-428f31fcee67.png)

after
![image](https://user-images.githubusercontent.com/48053804/137961690-753b3ea6-8155-403a-9279-de4e8843fc35.png)
