### PR TITLE
Fix: add `ts-ignore` to fix deploy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Deploy issues with `//@ts-ignore`
+
 ## [0.18.1] - 2023-07-11
 
 ### Fixed

--- a/react/IconArrowBack.tsx
+++ b/react/IconArrowBack.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconArrowBack = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-arrow-back" handle="arrowBackIcon" {...props} />
 }
 

--- a/react/IconAssistantSales.tsx
+++ b/react/IconAssistantSales.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconAssistantSales = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-telemarketing" handle="assistantSalesIcon" {...props} />
 }
 

--- a/react/IconBookmark.tsx
+++ b/react/IconBookmark.tsx
@@ -5,6 +5,7 @@ import { getType } from './utils/helpers'
 
 const IconBoomark = ({ type = 'outline', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type, 'filled, outline')
+  // @ts-ignore
   return <Icon id={`mpa-bookmark${typeModifier}`} {...props} />
 }
 

--- a/react/IconCaret.tsx
+++ b/react/IconCaret.tsx
@@ -9,6 +9,7 @@ const IconCaret = ({ orientation, thin = false, ...props }: CaretProps) => {
     [`nav-thin-caret${orientationModifier}`]: thin,
     [`nav-caret${orientationModifier}`]: !thin,
   })
+  // @ts-ignore
   return <Icon id={id} handle="caretIcon" {...props} />
 }
 

--- a/react/IconCart.tsx
+++ b/react/IconCart.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconCart = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-cart" handle="cartIcon" {...props} />
 }
 

--- a/react/IconCheck.tsx
+++ b/react/IconCheck.tsx
@@ -5,6 +5,7 @@ import Icon from './components/Icon'
 
 const IconCheck = ({ type, ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
+  // @ts-ignore
   return <Icon handle="checkIcon" id={`sti-check${typeModifier}`} {...props} />
 }
 

--- a/react/IconClose.tsx
+++ b/react/IconClose.tsx
@@ -5,6 +5,7 @@ import { getType } from './utils/helpers'
 
 const IconClose = ({ type = 'filled', ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type)
+  // @ts-ignore
   return <Icon handle="closeIcon" id={`sti-close${typeModifier}`} {...props} />
 }
 

--- a/react/IconDelete.tsx
+++ b/react/IconDelete.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconDelete = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-delete" handle="deleteIcon" {...props} />
 }
 

--- a/react/IconEquals.tsx
+++ b/react/IconEquals.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconEquals = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="sti-equals" handle="equalsIcon" {...props} />
 }
 

--- a/react/IconExpand.tsx
+++ b/react/IconExpand.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconExpand = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-expand" handle="expandIcon" {...props} />
 }
 

--- a/react/IconEyeSight.tsx
+++ b/react/IconEyeSight.tsx
@@ -6,6 +6,7 @@ import { getType, getState } from './utils/helpers'
 const IconEyeSight = ({ type, state, ...props }: EnhancedIconProps) => {
   const typeModifier = getType(type, 'filled, outline')
   const stateModifier = getState(state)
+  // @ts-ignore
   return (
     <Icon
       id={`mpa-eyesight${typeModifier}${stateModifier}`}

--- a/react/IconFilter.tsx
+++ b/react/IconFilter.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconFilter = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-filter-settings" handle="filterIcon" {...props} />
 }
 

--- a/react/IconGlobe.tsx
+++ b/react/IconGlobe.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGlobe = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-globe" handle="globeIcon" {...props} />
 }
 

--- a/react/IconGrid.tsx
+++ b/react/IconGrid.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconGrid = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-gallery" handle="gridIcon" {...props} />
 }
 

--- a/react/IconHeart.tsx
+++ b/react/IconHeart.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHeart = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-heart" handle="heartIcon" {...props} />
 }
 

--- a/react/IconHome.tsx
+++ b/react/IconHome.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconHome = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="nav-home" handle="homeIcon" {...props} />
 }
 

--- a/react/IconInlineGrid.tsx
+++ b/react/IconInlineGrid.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconInlineGrid = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-list-items" handle="inlineGridIcon" {...props} />
 }
 

--- a/react/IconLocationInput.tsx
+++ b/react/IconLocationInput.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconLocationInput = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-location-input" handle="locationInputIcon" {...props} />
 }
 

--- a/react/IconLocationMarker.tsx
+++ b/react/IconLocationMarker.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconLocationMarker = (props: IconProps) => {
+  // @ts-ignore
   return (
     <Icon id="hpa-location-marker" handle="locationMarkerIcon" {...props} />
   )

--- a/react/IconMenu.tsx
+++ b/react/IconMenu.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMenu = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-hamburguer-menu" handle="menuIcon" {...props} />
 }
 

--- a/react/IconMinus.tsx
+++ b/react/IconMinus.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconMinus = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="nav-minus" handle="minusIcon" {...props} />
 }
 

--- a/react/IconPause.tsx
+++ b/react/IconPause.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPause = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-pause" handle="pauseIcon" {...props} />
 }
 

--- a/react/IconPlay.tsx
+++ b/react/IconPlay.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPlay = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-play" handle="playIcon" {...props} />
 }
 

--- a/react/IconPlus.tsx
+++ b/react/IconPlus.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconPlus = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="nav-plus" handle="plusIcon" {...props} />
 }
 

--- a/react/IconProfile.tsx
+++ b/react/IconProfile.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconProfile = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-profile" handle="profileIcon" {...props} />
 }
 

--- a/react/IconRemove.tsx
+++ b/react/IconRemove.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconRemove = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-remove" handle="removeIcon" {...props} />
 }
 

--- a/react/IconSearch.tsx
+++ b/react/IconSearch.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSearch = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="hpa-search" handle="searchIcon" {...props} />
 }
 

--- a/react/IconSingleGrid.tsx
+++ b/react/IconSingleGrid.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSingleGrid = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-single-item" handle="singleGridIcon" {...props} />
 }
 

--- a/react/IconSocial.tsx
+++ b/react/IconSocial.tsx
@@ -10,7 +10,7 @@ interface Props extends EnhancedIconProps {
 
 const IconSocial = ({ network, size, background, shape, ...props }: Props) => {
   const { wrapperProps, reducedIconSize } = getShape(size!, background, shape)
-
+  // @ts-ignore
   return (
     <span {...wrapperProps}>
       <Icon

--- a/react/IconStar.tsx
+++ b/react/IconStar.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconStar = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="inf-star" handle="starIcon" {...props} />
 }
 

--- a/react/IconSwap.tsx
+++ b/react/IconSwap.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconSwap = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="mpa-swap" handle="swapIcon" {...props} />
 }
 

--- a/react/IconVolumeOff.tsx
+++ b/react/IconVolumeOff.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconVolumeOff = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="sti-volume-off" handle="volumeOffIcon" {...props} />
 }
 

--- a/react/IconVolumeOn.tsx
+++ b/react/IconVolumeOn.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Icon from './components/Icon'
 
 const IconVolumeOn = (props: IconProps) => {
+  // @ts-ignore
   return <Icon id="sti-volume-on" handle="volumeOnIcon" {...props} />
 }
 


### PR DESCRIPTION
#### What problem is this solving?

We're facing deployment failures when attempting to update the app, and it seems to be related to the declared components (refer to the image below). This PR aims to resolve this issue by adding `// @ts-ignore` before component declarations to see if it stops the error.

![Screenshot](https://github.com/vtex-apps/store-icons/assets/67270558/c84ccd71-823b-4014-a5c8-86e597c95709)

Previously, in PR #76 , I attempted to address markdown issues, but the deployment still failed.

@vitorflg suggested adding `// @ts-ignore` before declaring the component to potentially resolve the error and successfully publish and deploy the new app version.

However, we are uncertain if this change might impact the application negatively, and we would like confirmation with @vtex-apps/store-framework-devs before proceeding with this solution.