### PR TITLE
Bump to a new patch version - Release v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Bump to v0.19.3
+
 ## [0.19.2] - 2026-04-28
 
 ## [0.19.1] - 2026-04-27

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-icons",
   "vendor": "vtex",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "title": "VTEX Store icons",
   "description": "All icons that store apps use.",
   "mustUpdateAt": "2020-01-30",


### PR DESCRIPTION
#### What problem is this solving?

Version 0.19.2 was successfully published as a Release Candidate, but cannot be deployed due to a state validation error in the VTEX registry:

```
[Error: Cannot validate version which current state is different from Release Candidate](error: Error patching publication metadata in new index: The state of vtex.store-icons@0.19.2 could not be patched: Cannot validate version which current state is different from Release Candidate)
```

This prevented the app from being promoted from RC to stable despite the successful publication and merged PR #85.

##### Root Cause

The VTEX app registry encountered an inconsistent state where the app version metadata could not be properly validated during deployment, likely due to internal registry state corruption.

##### Resolution
Bumped the version to 0.19.3 to create a fresh version without the corrupted state. This allows the app to go through the normal publish → deploy lifecycle successfully.

##### Changes
Updated manifest.json: 0.19.2 → 0.19.3
