### PR TITLE
Bump version from 0.19.2 to 0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Bump version from 0.19.2 to 0.19.4
+
 ## [0.19.2] - 2026-04-28
 
 ## [0.19.1] - 2026-04-27

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-icons",
   "vendor": "vtex",
-  "version": "0.19.2",
+  "version": "0.19.4",
   "title": "VTEX Store icons",
   "description": "All icons that store apps use.",
   "mustUpdateAt": "2020-01-30",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.store-icons",
-  "version": "0.19.2",
+  "version": "0.19.4",
   "description": "React components that encapsules store icons",
   "scripts": {
     "pretest": "yarn",


### PR DESCRIPTION
#### What problem is this solving?

Version 0.19.2 was successfully published as a Release Candidate, but cannot be deployed due to a state validation error in the VTEX registry:

```
[Error: Cannot validate version which current state is different from Release Candidate](error: Error patching publication metadata in new index: The state of vtex.store-icons@0.19.2 could not be patched: Cannot validate version which current state is different from Release Candidate)
```

This prevented the app from being promoted from RC to stable, despite the successful publication and merged PR https://github.com/vtex-apps/store-icons/pull/85.

v0.19.3 was published, but it was deprecated before deployment.

This PR bumps master to v0.19.4 as the new stable release.